### PR TITLE
docs: CONTRIBUTING.md / CLAUDE.md を追加（landbase規約をスリム化）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,175 @@
+# CLAUDE.md - Claude 向けクイックリファレンス
+
+このドキュメントは Claude（AI 開発アシスタント）がこのプロジェクトを素早く理解し、適切に支援するためのクイックリファレンスです。
+
+**詳細な開発規約は [`CONTRIBUTING.md`](./CONTRIBUTING.md)、技術選定は [`docs/tech-stack.md`](./docs/tech-stack.md) を参照してください。**
+
+---
+
+## プロジェクト概要
+
+**okinawa-lodging-tax** — 沖縄県宿泊税の税額算定・集計・帳簿保存・領収書発行・申告用データ出力を行うアプリ。
+
+### 性格
+
+- **1施設=1インスタンスの汎用アプリ**（マルチテナント SaaS ではない）
+- **第一の顧客は本リポジトリ運営会社の自社民泊**（ドッグフーディング前提）
+- 会社運営のため **スタッフ2〜3人のマルチユーザー** で運用される
+- 社の方針として `landbase_ai_suite` の技術スタックと開発規約を踏襲
+
+### 現在のフェーズ
+
+**v0 要件定義フェーズは完了**。実装着手前。次のステップは [README.md の「次のステップ」](./README.md#次のステップ) 参照。
+
+---
+
+## 技術スタック（要点）
+
+- **Rails 8.0.2.1** / **Ruby 3.4.6**
+- **PostgreSQL 16**
+- **Devise** (認証) / **Solid Queue・Cache・Cable**（Redis 不要）
+- **paper_trail**（履歴・税務監査）
+- **Prawn**（領収書 PDF）/ **combine_pdf**（PDF 結合）
+- **Tailwind CSS** + **Hotwire** (importmap / Turbo / Stimulus)
+- **RSpec** + factory_bot + faker
+- **Kamal 2** デプロイ
+- **Docker Compose** ローカル環境
+
+詳細は [`docs/tech-stack.md`](./docs/tech-stack.md) を参照。
+
+---
+
+## 主要ドキュメント（読む順序）
+
+| 順序 | ドキュメント | 内容 |
+|---|---|---|
+| 1 | [`README.md`](./README.md) | プロジェクト全体像、ステータス、次のステップ |
+| 2 | [`docs/v0-requirements.md`](./docs/v0-requirements.md) ⭐ | v0 機能要件、データモデル、税計算 IF |
+| 3 | [`docs/non-functional-requirements.md`](./docs/non-functional-requirements.md) | 非機能要件（保存期間 / RPO・RTO / 監査 / セキュリティ） |
+| 4 | [`docs/tech-stack.md`](./docs/tech-stack.md) | 技術スタック選定（landbase 踏襲）と運用方針 |
+| 5 | [`docs/paper-ledger-template.md`](./docs/paper-ledger-template.md) | 紙台帳テンプレート（Stay と 1:1 対応） |
+| 6 | [`CONTRIBUTING.md`](./CONTRIBUTING.md) | 開発規約・コミット規約・PR フロー |
+
+> [`docs/requirements.md`](./docs/requirements.md) は SaaS拡張時の参考資料。**v0 のソースオブトゥルースは `v0-requirements.md`**。
+
+---
+
+## よく使うコマンド
+
+> Rails アプリ実装着手後に追記します。現状は雛形のみ。
+
+```bash
+# (TBD) make up        # Docker Compose 起動
+# (TBD) make down      # 停止
+# (TBD) make test      # RSpec 実行
+# (TBD) bin/rails console
+```
+
+---
+
+## 重要な設計原則
+
+### 規律 1: ユーザー固有データはコードに書かない
+
+施設名・住所・登録番号・チャネル名・領収書ロゴ等は **`config/facility.json`** に集約する。
+コード内ハードコードは禁止。
+
+### 規律 2: 税ロジックは Service Object に切り出す
+
+`app/services/okinawa_tax_calculator.rb` (仮) のように、税計算ロジックは Rails の Service Object として独立させる。
+条例改定への対応は **`tax_rule_version` フィールド** で吸収し、過去の Stay は当時の version で再計算可能にする。
+
+> **対応自治体スコープ（沖縄限定 vs 多自治体）はチーム議論で確定する論点**。現状ドキュメントは多自治体想定の表現が混在しているが、議論結果次第で整理する。
+
+### 規律 3: 領収書・帳票はテンプレート化
+
+ロゴ・住所・但し書き等はコードに直書きせず、テンプレート + 設定で差し替え可能にする。
+
+### マルチテナントは採用しない
+
+landbase との大きな差分。本プロジェクトは 1 施設 1 インスタンス前提のため `client_code` スコープは不要。
+
+---
+
+## コミット・ブランチ規約（要点）
+
+詳細は [`CONTRIBUTING.md`](./CONTRIBUTING.md) を参照。
+
+### ブランチ
+
+```
+<type>/<issue番号>-<機能名>
+例: feature/12-stay-form, docs/8-tech-stack
+```
+
+### コミット
+
+```
+<type>(<scope>): <subject> (issue#<番号>)
+例: feat(app): 領収書PDF生成サービスを実装 (issue#21)
+```
+
+### 禁止事項
+
+- ❌ `main` ブランチへの直接プッシュ
+- ❌ AI ツール署名（`Co-Authored-By: Claude` など）
+- ❌ Issue 番号なしのコミット
+- ❌ `--no-verify` で hook をスキップ
+
+### マージ戦略
+
+**Squash and Merge** を推奨（1 PR = 1 コミット）。
+
+---
+
+## セキュリティチェック（要点）
+
+```ruby
+# 1. SQL インジェクション対策（パラメータバインディング）
+Stay.where("guest_name LIKE ?", "%#{params[:q]}%")  # ✅
+Stay.where("guest_name LIKE '%#{params[:q]}%'")     # ❌
+
+# 2. Strong Parameters
+params.require(:stay).permit(:check_in_date, :nights, :guest_name, ...)
+
+# 3. 認証
+before_action :authenticate_user!
+```
+
+詳細は [`CONTRIBUTING.md` セキュリティチェック](./CONTRIBUTING.md#セキュリティチェック) 参照。
+
+---
+
+## 自動実行ポリシー
+
+### 確認なしで実行可能
+
+- ファイル読み取り: Read, Grep, Glob
+- 状態確認: `git status`, `git log`, `git diff`, `gh pr list`
+- ドキュメント編集（`docs/`, `README.md`, `CONTRIBUTING.md`, `CLAUDE.md`）
+- ブランチ作成・切替（main 以外への切替）
+
+### 必ず確認が必要
+
+- データベース操作（`db:migrate`, `db:drop`, `db:reset`）
+- `git push` / `gh pr merge` / `gh pr create`
+- 本番環境への操作（Kamal デプロイ、環境変数変更）
+- ファイル削除（`rm`, `git rm`）
+
+**原則**: 永続的な変更や元に戻せない操作は必ず確認する。
+
+---
+
+## メモリとの関係
+
+ユーザーの auto memory に本プロジェクトの背景情報が保存されています:
+
+- `okinawa_lodging_tax.md` — プロジェクト性格・運営状況・landbase との関係
+- `feedback_tech_stack_exclusions.md` — 技術スタック方針（Rails 主軸 / WordPress 不採用）
+- `landbase.md` — landbase_ai_suite の概要
+
+メモリの内容と本ドキュメントが食い違っている場合は、**本ドキュメント（リポジトリ内）を優先**してください。メモリは観測時点のスナップショットです。
+
+---
+
+**Last Updated**: 2026-04-07

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,280 @@
+# 開発ガイド
+
+okinawa-lodging-tax プロジェクトへの貢献ガイドです。
+本プロジェクトは社の方針として [`landbase_ai_suite`](https://github.com/AI-LandBase/landbase_ai_suite) の開発規約を踏襲し、本プロジェクトの規模に合わせてスリム化したものを採用しています。
+
+詳細な背景は [docs/tech-stack.md §2 開発規約](./docs/tech-stack.md#2-開発規約landbase踏襲) も参照してください。
+
+---
+
+## 目次
+
+- [Issue 作成ガイド](#issue-作成ガイド)
+- [Git ワークフロー](#git-ワークフロー)
+- [ブランチ命名規則](#ブランチ命名規則)
+- [コミット規約](#コミット規約)
+- [PR 作成フロー](#pr-作成フロー)
+- [コーディング規約](#コーディング規約)
+- [テスト方針](#テスト方針)
+- [セキュリティチェック](#セキュリティチェック)
+
+---
+
+## Issue 作成ガイド
+
+新機能・バグ修正・ドキュメント追加に着手する前に、必ず GitHub Issue を作成します。Issue は実装の設計書であり、レビュー時の比較基準になります。
+
+### Issue テンプレート
+
+`.github/ISSUE_TEMPLATE/` のテンプレートから選択してください。
+
+### 軽量版テンプレート（テンプレを使わない時の最低限）
+
+```markdown
+## 概要
+[1-2行で何をするか]
+
+## 背景・課題
+[なぜ必要か / 現状の問題]
+
+## 受け入れ基準
+- [ ] [Must条件1]
+- [ ] [Must条件2]
+
+## 関連
+- 関連 Issue: #XX
+- 関連 ドキュメント: [docs/...](./docs/...)
+```
+
+### 優先度
+
+| レベル | 説明 |
+|---|---|
+| **High** | 本番運用ブロッカー、セキュリティ問題、税計算ロジックの誤り |
+| **Medium** | 新機能、UX 改善 |
+| **Low** | 体裁修正、ドキュメント微修正 |
+
+### 工数見積
+
+landbase 同様の詳細な見積テンプレ（バッファ込み）を要するのは **High 優先度の Issue のみ**。それ以外は省略可。
+
+詳細が必要な場合は landbase の [CONTRIBUTING.md 工数見積ガイドライン](https://github.com/AI-LandBase/landbase_ai_suite/blob/main/CONTRIBUTING.md) を参照。
+
+---
+
+## Git ワークフロー
+
+[GitHub Flow](https://docs.github.com/ja/get-started/quickstart/github-flow) を採用します。
+
+### 基本フロー
+
+```
+1. Issue 作成 → 2. ブランチ作成 → 3. 実装 → 4. PR 作成 → 5. レビュー → 6. Squash and Merge
+```
+
+### 🚨 重要原則
+
+- **`main` ブランチへの直接プッシュは禁止**（PR 経由のみ）
+- **`main` で直接作業しない**（必ずブランチを切る）
+- 作業開始前に **`main` を最新化**してから分岐する
+
+```bash
+# 正しい手順
+git checkout main
+git pull origin main
+git checkout -b feature/12-stay-form
+```
+
+---
+
+## ブランチ命名規則
+
+```
+<type>/<issue番号>-<機能名>
+```
+
+| Type | 用途 | 例 |
+|---|---|---|
+| `feature/` | 新機能開発 | `feature/12-stay-form` |
+| `bugfix/` | バグ修正 | `bugfix/15-tax-calc-rounding` |
+| `hotfix/` | 緊急修正 | `hotfix/22-receipt-pdf-crash` |
+| `refactor/` | リファクタリング | `refactor/18-extract-tax-service` |
+| `docs/` | ドキュメント変更 | `docs/8-tech-stack` |
+| `chore/` | ビルド・ツール設定 | `chore/3-rubocop-config` |
+
+---
+
+## コミット規約
+
+### Conventional Commits 準拠
+
+```
+<type>(<scope>): <subject> (issue#<番号>)
+```
+
+### Type 一覧
+
+| Type | 説明 | 例 |
+|---|---|---|
+| `feat` | 新機能 | `feat(app): 宿泊実績入力フォームを実装 (issue#12)` |
+| `fix` | バグ修正 | `fix(app): 連泊時の税額計算を修正 (issue#15)` |
+| `docs` | ドキュメント | `docs: tech-stack を追加 (issue#7)` |
+| `refactor` | リファクタリング | `refactor(app): TaxCalculator を Service に抽出 (issue#18)` |
+| `test` | テスト追加・修正 | `test(app): Stay モデルのテストを追加 (issue#12)` |
+| `chore` | ビルド・ツール設定 | `chore(docker): compose の Postgres を 16 に固定 (issue#3)` |
+| `perf` | パフォーマンス改善 | `perf(app): 月次集計の N+1 を解消 (issue#19)` |
+| `style` | コードスタイル | `style: RuboCop 違反を修正 (issue#20)` |
+
+### Scope（任意）
+
+- `app` — Rails アプリ本体
+- `docker` — Docker / Compose 設定
+- `db` — データベース・マイグレーション
+- `docs` — ドキュメント
+- `infra` — Kamal / デプロイ設定
+
+### 禁止事項
+
+- ❌ **AI ツール署名の追加**（`Co-Authored-By: Claude` 等は付けない）
+- ❌ **issue 番号の省略**（小さい雑多な作業でも必ず Issue を立てて番号を付ける）
+- ❌ **`WIP` / `update` / `fix bug` 等の意味のないメッセージ**
+
+### 良い例 / 悪い例
+
+```bash
+# ✅ GOOD
+feat(app): 領収書PDF生成サービスを実装 (issue#21)
+fix(app): 課税対象人数の整合チェックを修正 (issue#23)
+docs: 紙台帳テンプレートを追加 (issue#9)
+
+# ❌ BAD
+update
+fix bug
+WIP
+🤖 Generated with Claude Code
+```
+
+---
+
+## PR 作成フロー
+
+### 1. PR 作成
+
+`.github/PULL_REQUEST_TEMPLATE.md` のテンプレートに沿って作成します。`gh pr create` で作る場合も同じ内容を `--body` に入れます。
+
+### 2. レビュー対応
+
+- レビューコメントには返答を残す（修正反映 or 議論）
+- 修正は追加コミットで（force-push せず履歴を残す。Squash で消える）
+
+### 3. マージ戦略: **Squash and Merge** を推奨
+
+- 1 PR = 1 コミットとして `main` に記録される
+- PR タイトルが Conventional Commits 形式のコミットメッセージになる
+- WIP コミットや修正コミットが `main` に残らない
+
+```
+# PR内のコミット履歴（開発中）
+- WIP: 初期実装
+- fix: typo
+- refactor: レビュー対応
+
+↓ Squash and Merge
+
+# main のコミット履歴
+- feat(app): 領収書PDF生成サービスを実装 (issue#21)
+```
+
+### 4. マージ後
+
+```bash
+git checkout main
+git pull origin main
+# ローカルブランチは GitHub 側で自動削除される設定
+```
+
+---
+
+## コーディング規約
+
+> Rails アプリ実装着手後に詳細を追記します。現状は方針のみ。
+
+### Ruby / Rails
+
+- **Service Object パターン**: 複雑なビジネスロジック（税計算・PDF生成・エクスポート）は `app/services/` に切り出す
+- **早期リターン**: ネストを深くしない
+- **RuboCop 準拠**: `rubocop-rails-omakase` を採用。`bundle exec rubocop` で確認、`bundle exec rubocop -a` で自動修正
+- **N+1 回避**: `includes` で eager loading、`Bullet` (development) で検出
+
+### JavaScript / Stimulus
+
+- Hotwire (Turbo + Stimulus) で記述
+- SPA フレームワーク（React/Vue 等）は使わない
+
+### データベース
+
+- マイグレーションは `down` 実装必須（landbase 規約踏襲）
+- **全カラムに `comment:` 必須**（税務監査時の自己説明性のため特に重要）
+- インデックス追加は `algorithm: :concurrently` を活用（本番ロックを避ける）
+- 詳細は [docs/tech-stack.md §5.4 マイグレーション戦略](./docs/tech-stack.md#54-マイグレーション戦略) 参照
+
+---
+
+## テスト方針
+
+- **RSpec 必須**: すべての新機能・修正にテストを追加
+- **カバレッジ閾値**: v0 段階では厳密な閾値を設けない。ただし税計算ロジック (`OkinawaTaxCalculator`) は**ケース網羅を強く推奨**
+- **テスト種別**:
+  - モデル spec
+  - リクエスト spec（コントローラの代わりに request spec を使う）
+  - system spec（領収書PDF生成・月次確定等のクリティカルパス）
+
+> Rails アプリ実装着手後に具体的な実行コマンドを追記します。
+
+---
+
+## セキュリティチェック
+
+### SQL インジェクション対策
+
+```ruby
+# ✅ DO: パラメータバインディング
+Stay.where("guest_name LIKE ?", "%#{params[:q]}%")
+
+# ❌ DON'T: 文字列補間
+Stay.where("guest_name LIKE '%#{params[:q]}%'")
+```
+
+### Strong Parameters
+
+```ruby
+# ✅ DO
+params.require(:stay).permit(:check_in_date, :nights, :guest_name, :num_guests, ...)
+```
+
+### 認証
+
+```ruby
+# 全コントローラの before_action で認証を必須にする
+before_action :authenticate_user!
+```
+
+### XSS 対策
+
+- ERB の自動エスケープを維持（`raw` / `html_safe` は原則使わない）
+
+### CSRF 対策
+
+- Rails 標準の `protect_from_forgery` を維持
+
+---
+
+## 参考リンク
+
+- [プロジェクト技術スタック](./docs/tech-stack.md)
+- [v0 要件定義](./docs/v0-requirements.md)
+- [非機能要件](./docs/non-functional-requirements.md)
+- [紙台帳テンプレート](./docs/paper-ledger-template.md)
+- [GitHub Flow](https://docs.github.com/ja/get-started/quickstart/github-flow)
+- [Conventional Commits](https://www.conventionalcommits.org/)
+- [landbase_ai_suite CONTRIBUTING.md](https://github.com/AI-LandBase/landbase_ai_suite/blob/main/CONTRIBUTING.md) — 詳細版（本プロジェクトはこれをスリム化したもの）


### PR DESCRIPTION
## 概要

検討基盤の弱点として指摘した「議論の作法がリポジトリに埋め込まれていない」を解消する PR その1。
landbase_ai_suite の規約をベースに、本プロジェクト規模に合わせてスリム化したものを採用。

## 追加ドキュメント

### CONTRIBUTING.md
- Issue 作成ガイド（軽量版テンプレ含む）
- Git ワークフロー（GitHub Flow）
- ブランチ命名規則（\`<type>/<issue番号>-<機能名>\`）
- コミット規約（Conventional Commits + issue番号必須 + AI署名禁止）
- PR 作成フロー（Squash and Merge 推奨）
- コーディング規約（Service Object / 早期リターン / RuboCop omakase）
- テスト方針（RSpec、税計算ロジックはケース網羅推奨）
- セキュリティチェック

### CLAUDE.md
- プロジェクト概要・性格・現フェーズ
- 技術スタック要点
- ドキュメント読み順
- 設計原則（規律1〜3、マルチテナント不採用）
- コミット・ブランチ規約要点
- 自動実行ポリシー（確認なしで可 / 必ず確認）
- メモリとの関係（食い違ったらリポジトリ優先）

## landbase 版との差分

- 工数見積の詳細テンプレは High 優先度のみ要求（通常は省略可）
- マルチテナント関連の規約は削除（本プロジェクトは1施設1インスタンス）
- API トークン関連は削除（v0 は外部 API なし）
- Rails 実装系コマンドは現状 TBD（Rails 初期化時に追記）

## 関連

- README の検討基盤評価で挙げた 3 つの優先課題のうち 1 つを解消
  - ✅ 議論の作法をリポジトリに埋め込む（本 PR）
  - ⬜ 古い requirements.md の整理（PR B で対応予定）
  - ⬜ Issue/PR テンプレ整備（PR B で対応予定）