### PR TITLE
feat(app): 税計算サービス TaxRules::Base / TaxRules::Okinawa を実装 (issue#32)

### DIFF
--- a/app/services/tax_rules/base.rb
+++ b/app/services/tax_rules/base.rb
@@ -1,0 +1,36 @@
+# 自治体プラグインの抽象基底クラス。
+# 各自治体は本クラスを継承し、#calculate と #summarize を実装する。
+#
+# 新しい自治体に対応する場合:
+#   app/services/tax_rules/<prefecture>.rb を追加し、
+#   TaxRules::Base を継承して #calculate と #summarize を実装する。
+module TaxRules
+  class Base
+    # 自治体識別子（例: "okinawa"）。サブクラスで定義。
+    ID = nil
+    # 表示ラベル（例: "沖縄県宿泊税"）。サブクラスで定義。
+    LABEL = nil
+    # 条例 version（例: "okinawa-2027-02-01"）。条例改定時に新しい値を発行する。
+    # 命名規則: "<prefecture>-<施行日 YYYY-MM-DD>"。
+    VERSION = nil
+
+    # 単一 Stay から税額を計算する。
+    #
+    # @param input [Hash] :nightly_rate, :nights, :num_taxable_guests
+    # @return [Hash] :taxable_amount, :tax_amount, :breakdown
+    def calculate(input)
+      raise NotImplementedError
+    end
+
+    # 期間 + Stay 一覧から月次集計を返す。
+    #
+    # @param stays [Array<Stay>] 対象期間に含まれる Stay レコード
+    # @param year_month [String] "YYYY-MM"
+    # @return [Hash] :year_month, :total_guests, :total_taxable_guests,
+    #                :total_taxable_amount, :total_tax_amount,
+    #                :details(Array)
+    def summarize(stays, year_month)
+      raise NotImplementedError
+    end
+  end
+end

--- a/app/services/tax_rules/okinawa.rb
+++ b/app/services/tax_rules/okinawa.rb
@@ -1,0 +1,71 @@
+# 沖縄県宿泊税の税額計算サービス。
+#
+# 令和8年沖縄県条例第1号「沖縄県宿泊税条例」および同施行規則（沖縄県規則第2号）に準拠。
+# 施行日: 2027-02-01
+#
+# 本クラスは沖縄県標準スキーム（併課区域を除く）のみを実装する。
+# 附則第4項の併課区域用税率（100分の0.8）は v0 スコープ外。
+module TaxRules
+  class Okinawa < Base
+    ID      = "okinawa"
+    LABEL   = "沖縄県宿泊税"
+    VERSION = "okinawa-2027-02-01"
+
+    # 税率 2%（条例第6条）
+    TAX_RATE = 0.02
+
+    # 課税標準上限 100,000 円/人泊（条例第5条）
+    TAXABLE_CAP = 100_000
+
+    # 単一 Stay から税額を計算する。
+    #
+    # 計算式（条例第5条・第6条準拠）:
+    #   per_person_per_night_taxable = min(nightly_rate, 100_000)
+    #   per_person_per_night_tax     = floor(per_person_per_night_taxable * 0.02)
+    #   taxable_amount = per_person_per_night_taxable * nights * num_taxable_guests
+    #   tax_amount     = per_person_per_night_tax     * nights * num_taxable_guests
+    #
+    # 端数処理: 1円未満切捨（地方税法通則の慣例。条例第6条に明示規定なし）
+    #
+    # @param input [Hash] :nightly_rate (Integer), :nights (Integer), :num_taxable_guests (Integer)
+    # @return [Hash] :taxable_amount, :tax_amount, :breakdown
+    def calculate(input)
+      nightly_rate       = input.fetch(:nightly_rate)
+      nights             = input.fetch(:nights)
+      num_taxable_guests = input.fetch(:num_taxable_guests)
+
+      # 条例第5条: 課税標準は1人1泊あたりの宿泊料金、上限10万円
+      per_person_per_night_taxable = [ nightly_rate, TAXABLE_CAP ].min
+
+      # 条例第6条: 税額 = 課税標準 × 税率（2%）、1円未満切捨
+      per_person_per_night_tax = (per_person_per_night_taxable * TAX_RATE).floor
+
+      taxable_amount = per_person_per_night_taxable * nights * num_taxable_guests
+      tax_amount     = per_person_per_night_tax * nights * num_taxable_guests
+
+      breakdown = "#{per_person_per_night_taxable}円/人泊 × #{TAX_RATE * 100}% = #{per_person_per_night_tax}円/人泊 × #{nights}泊 × #{num_taxable_guests}人 = #{tax_amount}円"
+
+      { taxable_amount: taxable_amount, tax_amount: tax_amount, breakdown: breakdown }
+    end
+
+    # 期間 + Stay 一覧から月次集計を返す。
+    #
+    # @param stays [Array<Stay>] 対象期間の Stay レコード（status: active のみ渡す想定）
+    # @param year_month [String] "YYYY-MM"
+    # @return [Hash]
+    def summarize(stays, year_month)
+      details = stays.map do |stay|
+        { stay_id: stay.id, taxable_amount: stay.taxable_amount, tax_amount: stay.tax_amount }
+      end
+
+      {
+        year_month: year_month,
+        total_guests: stays.sum(&:num_guests),
+        total_taxable_guests: stays.sum(&:num_taxable_guests),
+        total_taxable_amount: stays.sum(&:taxable_amount),
+        total_tax_amount: stays.sum(&:tax_amount),
+        details: details
+      }
+    end
+  end
+end

--- a/spec/services/tax_rules/okinawa_spec.rb
+++ b/spec/services/tax_rules/okinawa_spec.rb
@@ -1,0 +1,124 @@
+require "rails_helper"
+
+RSpec.describe TaxRules::Okinawa do
+  subject(:calculator) { described_class.new }
+
+  describe "定数" do
+    it "ID は okinawa" do
+      expect(described_class::ID).to eq("okinawa")
+    end
+
+    it "VERSION は okinawa-2027-02-01" do
+      expect(described_class::VERSION).to eq("okinawa-2027-02-01")
+    end
+
+    it "税率は 2%" do
+      expect(described_class::TAX_RATE).to eq(0.02)
+    end
+
+    it "課税標準上限は 100,000 円" do
+      expect(described_class::TAXABLE_CAP).to eq(100_000)
+    end
+  end
+
+  describe "#calculate" do
+    context "通常ケース: 8,000円/人泊 × 2泊 × 3人" do
+      let(:result) { calculator.calculate(nightly_rate: 8_000, nights: 2, num_taxable_guests: 3) }
+
+      it "課税対象合計 = 8,000 × 2 × 3 = 48,000" do
+        expect(result[:taxable_amount]).to eq(48_000)
+      end
+
+      it "税額 = floor(8,000 × 0.02) × 2 × 3 = 160 × 6 = 960" do
+        expect(result[:tax_amount]).to eq(960)
+      end
+
+      it "breakdown に計算根拠が含まれる" do
+        expect(result[:breakdown]).to include("8000円/人泊")
+        expect(result[:breakdown]).to include("960円")
+      end
+    end
+
+    context "上限超過: 150,000円/人泊 × 1泊 × 1人" do
+      let(:result) { calculator.calculate(nightly_rate: 150_000, nights: 1, num_taxable_guests: 1) }
+
+      it "課税標準は上限 100,000 円で打ち止め" do
+        expect(result[:taxable_amount]).to eq(100_000)
+      end
+
+      it "税額 = floor(100,000 × 0.02) × 1 × 1 = 2,000" do
+        expect(result[:tax_amount]).to eq(2_000)
+      end
+    end
+
+    context "上限ちょうど: 100,000円/人泊" do
+      let(:result) { calculator.calculate(nightly_rate: 100_000, nights: 1, num_taxable_guests: 1) }
+
+      it "課税標準 = 100,000" do
+        expect(result[:taxable_amount]).to eq(100_000)
+      end
+
+      it "税額 = 2,000" do
+        expect(result[:tax_amount]).to eq(2_000)
+      end
+    end
+
+    context "端数発生: 3,333円/人泊" do
+      let(:result) { calculator.calculate(nightly_rate: 3_333, nights: 1, num_taxable_guests: 1) }
+
+      it "税額 = floor(3,333 × 0.02) = floor(66.66) = 66" do
+        expect(result[:tax_amount]).to eq(66)
+      end
+    end
+
+    context "免除人数あり（課税対象0人）" do
+      let(:result) { calculator.calculate(nightly_rate: 10_000, nights: 1, num_taxable_guests: 0) }
+
+      it "税額 = 0" do
+        expect(result[:tax_amount]).to eq(0)
+      end
+
+      it "課税対象合計 = 0" do
+        expect(result[:taxable_amount]).to eq(0)
+      end
+    end
+
+    context "連泊: 5,000円/人泊 × 7泊 × 2人" do
+      let(:result) { calculator.calculate(nightly_rate: 5_000, nights: 7, num_taxable_guests: 2) }
+
+      it "課税対象合計 = 5,000 × 7 × 2 = 70,000" do
+        expect(result[:taxable_amount]).to eq(70_000)
+      end
+
+      it "税額 = floor(5,000 × 0.02) × 7 × 2 = 100 × 14 = 1,400" do
+        expect(result[:tax_amount]).to eq(1_400)
+      end
+    end
+
+    context "最小ケース: 1円/人泊 × 1泊 × 1人" do
+      let(:result) { calculator.calculate(nightly_rate: 1, nights: 1, num_taxable_guests: 1) }
+
+      it "税額 = floor(1 × 0.02) = floor(0.02) = 0" do
+        expect(result[:tax_amount]).to eq(0)
+      end
+    end
+  end
+
+  describe "#summarize" do
+    it "Stay 一覧から月次集計を返す" do
+      stays = [
+        double(id: 1, num_guests: 3, num_taxable_guests: 3, taxable_amount: 48_000, tax_amount: 960),
+        double(id: 2, num_guests: 2, num_taxable_guests: 2, taxable_amount: 20_000, tax_amount: 400)
+      ]
+
+      result = calculator.summarize(stays, "2027-03")
+
+      expect(result[:year_month]).to eq("2027-03")
+      expect(result[:total_guests]).to eq(5)
+      expect(result[:total_taxable_guests]).to eq(5)
+      expect(result[:total_taxable_amount]).to eq(68_000)
+      expect(result[:total_tax_amount]).to eq(1_360)
+      expect(result[:details].size).to eq(2)
+    end
+  end
+end


### PR DESCRIPTION
## 概要

- 沖縄県宿泊税条例準拠の税計算プラグイン構造（Base + Okinawa）を実装

## 変更内容

- `app/services/tax_rules/base.rb` — 抽象基底クラス（#calculate, #summarize）
- `app/services/tax_rules/okinawa.rb` — 沖縄県宿泊税（税率2%・上限10万円/人泊・1円未満切捨）
- RSpec 18件（通常・上限超過・端数発生・免除0人・連泊・最小ケース・月次集計）

## テスト方法

```bash
make test  # 32 examples, 0 failures
```

## チェックリスト

- [x] TaxRules::Base 抽象基底クラス
- [x] TaxRules::Okinawa の #calculate / #summarize
- [x] 条文番号の出典コメント
- [x] RSpec ケース網羅テスト 18件通過

Closes #32