### PR TITLE
fix(lint): RuboCop違反を修正 (issue#41)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -74,6 +74,6 @@ gem "combine_pdf", "~> 1.0"
 gem "pry-rails", "~> 0.3.11", group: :development
 gem "bullet", "~> 8.1", group: :development
 
-gem "rspec-rails", "~> 8.0", groups: [:development, :test]
-gem "factory_bot_rails", "~> 6.5", groups: [:development, :test]
-gem "faker", "~> 3.6", groups: [:development, :test]
+gem "rspec-rails", "~> 8.0", groups: [ :development, :test ]
+gem "factory_bot_rails", "~> 6.5", groups: [ :development, :test ]
+gem "faker", "~> 3.6", groups: [ :development, :test ]

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -7,6 +7,6 @@ Rails.application.config.middleware.insert_before 0, Rack::Cors do
 
     resource "*",
       headers: :any,
-      methods: [:get, :post, :put, :patch, :delete, :options, :head]
+      methods: [ :get, :post, :put, :patch, :delete, :options, :head ]
   end
 end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -24,7 +24,7 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = 'please-change-me-at-config-initializers-devise@example.com'
+  config.mailer_sender = "please-change-me-at-config-initializers-devise@example.com"
 
   # Configure the class responsible to send e-mails.
   # config.mailer = 'Devise::Mailer'
@@ -36,7 +36,7 @@ Devise.setup do |config|
   # Load and configure the ORM. Supports :active_record (default) and
   # :mongoid (bson_ext recommended) by default. Other ORMs may be
   # available as additional gems.
-  require 'devise/orm/active_record'
+  require "devise/orm/active_record"
 
   # ==> Configuration for any authentication mechanism
   # Configure which keys are used when authenticating a user. The default is

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -58,12 +58,12 @@ Devise.setup do |config|
   # Configure which authentication keys should be case-insensitive.
   # These keys will be downcased upon creating or modifying a user and when used
   # to authenticate or find a user. Default is :email.
-  config.case_insensitive_keys = [:email]
+  config.case_insensitive_keys = [ :email ]
 
   # Configure which authentication keys should have whitespace stripped.
   # These keys will have whitespace before and after removed upon creating or
   # modifying a user and when used to authenticate or find a user. Default is :email.
-  config.strip_whitespace_keys = [:email]
+  config.strip_whitespace_keys = [ :email ]
 
   # Tell if authentication through request.params is enabled. True by default.
   # It can be set to an array that will enable params authentication only for the
@@ -97,7 +97,7 @@ Devise.setup do |config|
   # Notice that if you are skipping storage for all authentication paths, you
   # may want to disable generating routes to Devise's sessions controller by
   # passing skip: :sessions to `devise_for` in your config/routes.rb
-  config.skip_session_storage = [:http_auth]
+  config.skip_session_storage = [ :http_auth ]
 
   # By default, Devise cleans up the CSRF token on authentication to
   # avoid CSRF token fixation attacks. This means that, when using AJAX

--- a/db/migrate/20260410004332_create_versions.rb
+++ b/db/migrate/20260410004332_create_versions.rb
@@ -1,7 +1,6 @@
 # This migration creates the `versions` table for the Version class.
 # All other migrations PT provides are optional.
 class CreateVersions < ActiveRecord::Migration[8.1]
-
   # The largest text column available in all supported RDBMS is
   # 1024^3 - 1 bytes, roughly one gibibyte.  We specify a size
   # so that MySQL will use `longtext` instead of `text`.  Otherwise,


### PR DESCRIPTION
## Summary
- `Gemfile`: 配列ブラケット内にスペース追加 (Layout/SpaceInsideArrayLiteralBrackets)
- `config/initializers/cors.rb`: 同上
- `config/initializers/devise.rb`: シングルクォートをダブルクォートに変更 (Style/StringLiterals)
- `db/migrate/20260410004332_create_versions.rb`: クラス定義直後の空行を削除 (Layout/EmptyLinesAroundClassBody)

Closes #41