### PR TITLE
feat(sales): 営業先リストのCRUD・Excelインポート機能を実装 (issue#54)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -70,6 +70,8 @@ gem "rails-i18n", "~> 8.1"
 gem "paper_trail", "~> 17.0"
 gem "prawn", "~> 2.5"
 gem "combine_pdf", "~> 1.0"
+gem "roo", "~> 2.10"
+gem "csv", "~> 3.3"
 
 gem "pry-rails", "~> 0.3.11", group: :development
 gem "bullet", "~> 8.1", group: :development

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -116,6 +116,7 @@ GEM
     concurrent-ruby (1.3.6)
     connection_pool (3.0.2)
     crass (1.0.6)
+    csv (3.3.5)
     date (3.5.1)
     debug (1.11.1)
       irb (~> 1.10)
@@ -365,6 +366,9 @@ GEM
     responders (3.2.0)
       actionpack (>= 7.0)
       railties (>= 7.0)
+    roo (2.10.1)
+      nokogiri (~> 1)
+      rubyzip (>= 1.3.0, < 3.0.0)
     rspec-core (3.13.6)
       rspec-support (~> 3.13.0)
     rspec-expectations (3.13.5)
@@ -415,6 +419,7 @@ GEM
     ruby-vips (2.3.0)
       ffi (~> 1.12)
       logger
+    rubyzip (2.4.1)
     securerandom (0.4.1)
     solid_cable (3.0.12)
       actioncable (>= 7.2)
@@ -498,6 +503,7 @@ DEPENDENCIES
   bullet (~> 8.1)
   bundler-audit
   combine_pdf (~> 1.0)
+  csv (~> 3.3)
   debug
   devise (~> 5.0)
   devise-i18n (~> 1.16)
@@ -517,6 +523,7 @@ DEPENDENCIES
   rack-cors (~> 3.0)
   rails (~> 8.1.2)
   rails-i18n (~> 8.1)
+  roo (~> 2.10)
   rspec-rails (~> 8.0)
   rubocop-rails-omakase
   solid_cable

--- a/app/controllers/sales_leads_controller.rb
+++ b/app/controllers/sales_leads_controller.rb
@@ -1,0 +1,56 @@
+class SalesLeadsController < ApplicationController
+  before_action :set_sales_lead, only: %i[show edit update]
+
+  def index
+    @sales_leads = SalesLead
+                   .by_region(params[:region])
+                   .by_segment(params[:segment])
+                   .by_priority(params[:priority])
+                   .by_sales_status(params[:sales_status])
+                   .order(created_at: :desc)
+  end
+
+  def show
+  end
+
+  def new
+    @sales_lead = SalesLead.new
+  end
+
+  def create
+    @sales_lead = SalesLead.new(sales_lead_params)
+
+    if @sales_lead.save
+      redirect_to sales_leads_path, notice: "営業先を登録しました"
+    else
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  def edit
+  end
+
+  def update
+    if @sales_lead.update(sales_lead_params)
+      redirect_to sales_lead_path(@sales_lead), notice: "営業先を更新しました"
+    else
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def set_sales_lead
+    @sales_lead = SalesLead.find(params[:id])
+  end
+
+  def sales_lead_params
+    params.require(:sales_lead).permit(
+      :facility_name, :segment, :area, :phone, :region,
+      :priority, :it_literacy, :sales_status, :person_in_charge,
+      :contacted_at, :appointment_date, :visited_at,
+      :proposal_amount, :subsidy_status, :closed_at, :monthly_start_date,
+      :memo, :source, :source_url, :duplicate_flag
+    )
+  end
+end

--- a/app/helpers/sales_leads_helper.rb
+++ b/app/helpers/sales_leads_helper.rb
@@ -1,0 +1,26 @@
+module SalesLeadsHelper
+  def priority_badge_class(priority)
+    base = "inline-block px-2 py-0.5 rounded text-xs font-medium"
+    case priority
+    when "最高" then "#{base} bg-red-100 text-red-800"
+    when "高"   then "#{base} bg-orange-100 text-orange-800"
+    when "中"   then "#{base} bg-yellow-100 text-yellow-800"
+    when "低"   then "#{base} bg-gray-100 text-gray-800"
+    else base
+    end
+  end
+
+  def sales_status_badge_class(status)
+    base = "inline-block px-2 py-0.5 rounded text-xs font-medium"
+    case status
+    when "未着手"     then "#{base} bg-gray-100 text-gray-800"
+    when "初回接触済" then "#{base} bg-blue-100 text-blue-800"
+    when "アポ取得"   then "#{base} bg-indigo-100 text-indigo-800"
+    when "訪問済"     then "#{base} bg-purple-100 text-purple-800"
+    when "提案済"     then "#{base} bg-yellow-100 text-yellow-800"
+    when "成約"       then "#{base} bg-green-100 text-green-800"
+    when "失注"       then "#{base} bg-red-100 text-red-800"
+    else base
+    end
+  end
+end

--- a/app/models/sales_lead.rb
+++ b/app/models/sales_lead.rb
@@ -1,0 +1,22 @@
+class SalesLead < ApplicationRecord
+  SEGMENTS = %w[大型ホテル・リゾート 中規模ビジネスホテル ペンション・コンドミニアム 民宿・ゲストハウス ペンション・貸別荘 その他].freeze
+  REGIONS = %w[北部 中部 南部].freeze
+  PRIORITIES = %w[最高 高 中 低].freeze
+  IT_LITERACIES = %w[高 中 低].freeze
+  SALES_STATUSES = %w[未着手 初回接触済 アポ取得 訪問済 提案済 成約 失注].freeze
+  SUBSIDY_STATUSES = %w[未申請 申請中 承認済 不採択].freeze
+
+  validates :facility_name, presence: true
+  validates :region, presence: true, inclusion: { in: REGIONS }
+  validates :segment, inclusion: { in: SEGMENTS }, allow_blank: true
+  validates :priority, inclusion: { in: PRIORITIES }, allow_blank: true
+  validates :it_literacy, inclusion: { in: IT_LITERACIES }, allow_blank: true
+  validates :sales_status, presence: true, inclusion: { in: SALES_STATUSES }
+  validates :subsidy_status, inclusion: { in: SUBSIDY_STATUSES }, allow_blank: true
+  validates :proposal_amount, numericality: { greater_than_or_equal_to: 0, only_integer: true }, allow_nil: true
+
+  scope :by_region, ->(region) { where(region: region) if region.present? }
+  scope :by_segment, ->(segment) { where(segment: segment) if segment.present? }
+  scope :by_priority, ->(priority) { where(priority: priority) if priority.present? }
+  scope :by_sales_status, ->(status) { where(sales_status: status) if status.present? }
+end

--- a/app/services/sales_lead_importer.rb
+++ b/app/services/sales_lead_importer.rb
@@ -1,0 +1,166 @@
+class SalesLeadImporter
+  Result = Struct.new(:created, :updated, :skipped, :errors, keyword_init: true)
+
+  REGION_MAP = {
+    "north" => "北部",
+    "chubu" => "中部",
+    "south" => "南部"
+  }.freeze
+
+  def initialize(file_path, region_key:)
+    @file_path = file_path
+    @region = REGION_MAP.fetch(region_key) { raise ArgumentError, "Unknown region_key: #{region_key}. Use: #{REGION_MAP.keys.join(', ')}" }
+    @region_key = region_key
+  end
+
+  def import
+    result = Result.new(created: 0, updated: 0, skipped: 0, errors: [])
+    spreadsheet = Roo::Spreadsheet.open(@file_path)
+    sheet = pick_sheet(spreadsheet)
+
+    headers = normalize_headers(sheet.row(1))
+    (2..sheet.last_row).each do |i|
+      row = Hash[headers.zip(sheet.row(i))]
+      import_row(row, result, i)
+    end
+
+    result
+  end
+
+  private
+
+  def pick_sheet(spreadsheet)
+    if @region_key == "chubu"
+      target = spreadsheet.sheets.find { |s| s.include?("営業管理") }
+      spreadsheet.sheet(target || spreadsheet.sheets.first)
+    else
+      target = spreadsheet.sheets.find { |s| s.include?("Deduped") }
+      spreadsheet.sheet(target || spreadsheet.sheets.first)
+    end
+  end
+
+  def normalize_headers(row)
+    row.map { |h| h.to_s.strip }
+  end
+
+  def import_row(row, result, row_number)
+    facility_name = row.values_at(*facility_name_keys).compact.first.to_s.strip
+    if facility_name.blank?
+      result.skipped += 1
+      return
+    end
+
+    phone = normalize_phone(row.values_at(*phone_keys).compact.first)
+
+    lead = SalesLead.find_or_initialize_by(
+      facility_name: facility_name,
+      phone: phone,
+      region: @region
+    )
+
+    assign_attributes(lead, row)
+
+    if lead.valid?
+      lead.new_record? ? result.created += 1 : result.updated += 1
+      lead.save!
+    else
+      result.errors << "Row #{row_number}: #{lead.errors.full_messages.join(', ')}"
+    end
+  rescue => e
+    result.errors << "Row #{row_number}: #{e.message}"
+  end
+
+  def assign_attributes(lead, row)
+    lead.assign_attributes(
+      segment: extract_segment(row),
+      area: extract_area(row),
+      source: extract_value(row, source_keys),
+      source_url: extract_value(row, source_url_keys),
+      duplicate_flag: extract_duplicate_flag(row)
+    )
+
+    assign_sales_fields(lead, row) if @region_key == "chubu"
+  end
+
+  def assign_sales_fields(lead, row)
+    lead.priority = extract_value(row, %w[優先度]) if extract_value(row, %w[優先度]).present?
+    lead.it_literacy = extract_value(row, %w[IT化度 IT化度推定]) if extract_value(row, %w[IT化度 IT化度推定]).present?
+    lead.sales_status = extract_sales_status(row) || lead.sales_status
+    lead.person_in_charge = extract_value(row, %w[担当者 担当]) if extract_value(row, %w[担当者 担当]).present?
+    lead.contacted_at = parse_date(extract_value(row, %w[初回接触日 接触日])) if extract_value(row, %w[初回接触日 接触日]).present?
+    lead.appointment_date = parse_date(extract_value(row, %w[アポ日])) if extract_value(row, %w[アポ日]).present?
+    lead.visited_at = parse_date(extract_value(row, %w[訪問日])) if extract_value(row, %w[訪問日]).present?
+    lead.proposal_amount = parse_amount(extract_value(row, %w[提案金額 提案額])) if extract_value(row, %w[提案金額 提案額]).present?
+    lead.subsidy_status = extract_value(row, %w[補助金申請状況 補助金 補助金申請]) if extract_value(row, %w[補助金申請状況 補助金 補助金申請]).present?
+    lead.closed_at = parse_date(extract_value(row, %w[成約日])) if extract_value(row, %w[成約日]).present?
+    lead.monthly_start_date = parse_date(extract_value(row, %w[月額開始日 月額開始])) if extract_value(row, %w[月額開始日 月額開始]).present?
+    lead.memo = extract_value(row, %w[メモ 備考]) if extract_value(row, %w[メモ 備考]).present?
+  end
+
+  def facility_name_keys
+    %w[施設名 宿泊施設名 ホテル名 名称]
+  end
+
+  def phone_keys
+    %w[電話番号 TEL tel Phone phone]
+  end
+
+  def source_keys
+    %w[ソース ソース分類 Source source]
+  end
+
+  def source_url_keys
+    %w[URL ソースURL url]
+  end
+
+  def extract_segment(row)
+    extract_value(row, %w[セグメント セグメント名 グループ])
+  end
+
+  def extract_area(row)
+    extract_value(row, %w[市町村 エリア 地域])
+  end
+
+  def extract_value(row, keys)
+    keys.each do |key|
+      val = row[key]
+      return val.to_s.strip if val.present?
+    end
+    nil
+  end
+
+  def extract_duplicate_flag(row)
+    val = extract_value(row, %w[重複候補 重複])
+    val.present?
+  end
+
+  def extract_sales_status(row)
+    val = extract_value(row, %w[営業ステータス ステータス])
+    return nil if val.blank?
+    SalesLead::SALES_STATUSES.include?(val) ? val : nil
+  end
+
+  def normalize_phone(value)
+    return nil if value.blank?
+    value.to_s.strip.gsub(/[^0-9\-]/, "")
+  end
+
+  def parse_date(value)
+    return nil if value.blank?
+    return value if value.is_a?(Date)
+    Date.parse(value.to_s)
+  rescue Date::Error
+    nil
+  end
+
+  def parse_amount(value)
+    return nil if value.blank?
+    return value.to_i if value.is_a?(Numeric)
+    cleaned = value.to_s.gsub(/[^\d.]/, "")
+    if value.to_s.include?("万")
+      (cleaned.to_f * 10_000).to_i
+    else
+      cleaned.to_i
+    end
+  end
+end

--- a/app/services/sales_lead_importer.rb
+++ b/app/services/sales_lead_importer.rb
@@ -18,8 +18,9 @@ class SalesLeadImporter
     spreadsheet = Roo::Spreadsheet.open(@file_path)
     sheet = pick_sheet(spreadsheet)
 
-    headers = normalize_headers(sheet.row(1))
-    (2..sheet.last_row).each do |i|
+    header_row = detect_header_row(sheet)
+    headers = normalize_headers(sheet.row(header_row))
+    ((header_row + 1)..sheet.last_row).each do |i|
       row = Hash[headers.zip(sheet.row(i))]
       import_row(row, result, i)
     end
@@ -37,6 +38,15 @@ class SalesLeadImporter
       target = spreadsheet.sheets.find { |s| s.include?("Deduped") }
       spreadsheet.sheet(target || spreadsheet.sheets.first)
     end
+  end
+
+  def detect_header_row(sheet)
+    (1..[ sheet.last_row, 5 ].min).each do |i|
+      row = sheet.row(i)
+      headers_str = row.compact.map(&:to_s)
+      return i if headers_str.any? { |h| h.include?("施設名") }
+    end
+    1
   end
 
   def normalize_headers(row)

--- a/app/services/sales_lead_importer.rb
+++ b/app/services/sales_lead_importer.rb
@@ -83,18 +83,40 @@ class SalesLeadImporter
   end
 
   def assign_sales_fields(lead, row)
-    lead.priority = extract_value(row, %w[優先度]) if extract_value(row, %w[優先度]).present?
-    lead.it_literacy = extract_value(row, %w[IT化度 IT化度推定]) if extract_value(row, %w[IT化度 IT化度推定]).present?
+    val = extract_value(row, %w[優先度])
+    lead.priority = val if val.present?
+
+    val = extract_value(row, %w[IT化度 IT化度推定])
+    lead.it_literacy = val if val.present?
+
     lead.sales_status = extract_sales_status(row) || lead.sales_status
-    lead.person_in_charge = extract_value(row, %w[担当者 担当]) if extract_value(row, %w[担当者 担当]).present?
-    lead.contacted_at = parse_date(extract_value(row, %w[初回接触日 接触日])) if extract_value(row, %w[初回接触日 接触日]).present?
-    lead.appointment_date = parse_date(extract_value(row, %w[アポ日])) if extract_value(row, %w[アポ日]).present?
-    lead.visited_at = parse_date(extract_value(row, %w[訪問日])) if extract_value(row, %w[訪問日]).present?
-    lead.proposal_amount = parse_amount(extract_value(row, %w[提案金額 提案額])) if extract_value(row, %w[提案金額 提案額]).present?
-    lead.subsidy_status = extract_value(row, %w[補助金申請状況 補助金 補助金申請]) if extract_value(row, %w[補助金申請状況 補助金 補助金申請]).present?
-    lead.closed_at = parse_date(extract_value(row, %w[成約日])) if extract_value(row, %w[成約日]).present?
-    lead.monthly_start_date = parse_date(extract_value(row, %w[月額開始日 月額開始])) if extract_value(row, %w[月額開始日 月額開始]).present?
-    lead.memo = extract_value(row, %w[メモ 備考]) if extract_value(row, %w[メモ 備考]).present?
+
+    val = extract_value(row, %w[担当者 担当])
+    lead.person_in_charge = val if val.present?
+
+    val = extract_value(row, %w[初回接触日 接触日])
+    lead.contacted_at = parse_date(val) if val.present?
+
+    val = extract_value(row, %w[アポ日])
+    lead.appointment_date = parse_date(val) if val.present?
+
+    val = extract_value(row, %w[訪問日])
+    lead.visited_at = parse_date(val) if val.present?
+
+    val = extract_value(row, %w[提案金額 提案額])
+    lead.proposal_amount = parse_amount(val) if val.present?
+
+    val = extract_value(row, %w[補助金申請状況 補助金 補助金申請])
+    lead.subsidy_status = val if val.present?
+
+    val = extract_value(row, %w[成約日])
+    lead.closed_at = parse_date(val) if val.present?
+
+    val = extract_value(row, %w[月額開始日 月額開始])
+    lead.monthly_start_date = parse_date(val) if val.present?
+
+    val = extract_value(row, %w[メモ 備考])
+    lead.memo = val if val.present?
   end
 
   def facility_name_keys

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -30,6 +30,7 @@
           <div class="flex items-center gap-6">
             <%= link_to "宿泊税管理", root_path, class: "font-bold text-lg hover:text-gray-900" %>
             <%= link_to "宿泊実績", stays_path, class: "text-gray-600 hover:text-gray-900" %>
+            <%= link_to "営業リスト", sales_leads_path, class: "text-gray-600 hover:text-gray-900" %>
             <%= link_to "ユーザー管理", users_path, class: "text-gray-600 hover:text-gray-900" %>
           </div>
           <div class="flex items-center gap-4 text-sm text-gray-600">

--- a/app/views/sales_leads/_form.html.erb
+++ b/app/views/sales_leads/_form.html.erb
@@ -1,0 +1,143 @@
+<%= form_with(model: sales_lead, class: "space-y-4 max-w-lg") do |f| %>
+  <% if sales_lead.errors.any? %>
+    <div class="bg-red-50 border border-red-300 rounded p-4">
+      <h2 class="text-red-800 font-medium mb-2"><%= sales_lead.errors.count %>件のエラーがあります</h2>
+      <ul class="list-disc list-inside text-red-700 text-sm">
+        <% sales_lead.errors.full_messages.each do |message| %>
+          <li><%= message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <h2 class="text-lg font-semibold border-b border-gray-300 pb-2">基本情報</h2>
+
+  <div>
+    <%= f.label :facility_name, "施設名", class: "block text-sm font-medium text-gray-700 mb-1" %>
+    <%= f.text_field :facility_name, class: "w-full border border-gray-300 rounded px-3 py-2", required: true %>
+  </div>
+
+  <div class="grid grid-cols-2 gap-4">
+    <div>
+      <%= f.label :region, "地域", class: "block text-sm font-medium text-gray-700 mb-1" %>
+      <%= f.select :region,
+            options_for_select(SalesLead::REGIONS, sales_lead.region),
+            { include_blank: "選択してください" },
+            class: "w-full border border-gray-300 rounded px-3 py-2", required: true %>
+    </div>
+    <div>
+      <%= f.label :area, "市町村", class: "block text-sm font-medium text-gray-700 mb-1" %>
+      <%= f.text_field :area, class: "w-full border border-gray-300 rounded px-3 py-2" %>
+    </div>
+  </div>
+
+  <div class="grid grid-cols-2 gap-4">
+    <div>
+      <%= f.label :segment, "セグメント", class: "block text-sm font-medium text-gray-700 mb-1" %>
+      <%= f.select :segment,
+            options_for_select(SalesLead::SEGMENTS, sales_lead.segment),
+            { include_blank: "選択してください" },
+            class: "w-full border border-gray-300 rounded px-3 py-2" %>
+    </div>
+    <div>
+      <%= f.label :phone, "電話番号", class: "block text-sm font-medium text-gray-700 mb-1" %>
+      <%= f.text_field :phone, class: "w-full border border-gray-300 rounded px-3 py-2" %>
+    </div>
+  </div>
+
+  <h2 class="text-lg font-semibold border-b border-gray-300 pb-2 mt-6">営業管理</h2>
+
+  <div class="grid grid-cols-3 gap-4">
+    <div>
+      <%= f.label :priority, "優先度", class: "block text-sm font-medium text-gray-700 mb-1" %>
+      <%= f.select :priority,
+            options_for_select(SalesLead::PRIORITIES, sales_lead.priority),
+            { include_blank: "選択してください" },
+            class: "w-full border border-gray-300 rounded px-3 py-2" %>
+    </div>
+    <div>
+      <%= f.label :it_literacy, "IT化度", class: "block text-sm font-medium text-gray-700 mb-1" %>
+      <%= f.select :it_literacy,
+            options_for_select(SalesLead::IT_LITERACIES, sales_lead.it_literacy),
+            { include_blank: "選択してください" },
+            class: "w-full border border-gray-300 rounded px-3 py-2" %>
+    </div>
+    <div>
+      <%= f.label :sales_status, "ステータス", class: "block text-sm font-medium text-gray-700 mb-1" %>
+      <%= f.select :sales_status,
+            options_for_select(SalesLead::SALES_STATUSES, sales_lead.sales_status),
+            {},
+            class: "w-full border border-gray-300 rounded px-3 py-2" %>
+    </div>
+  </div>
+
+  <div class="grid grid-cols-2 gap-4">
+    <div>
+      <%= f.label :person_in_charge, "担当者", class: "block text-sm font-medium text-gray-700 mb-1" %>
+      <%= f.text_field :person_in_charge, class: "w-full border border-gray-300 rounded px-3 py-2" %>
+    </div>
+    <div>
+      <%= f.label :proposal_amount, "提案金額（円・税抜）", class: "block text-sm font-medium text-gray-700 mb-1" %>
+      <%= f.number_field :proposal_amount, class: "w-full border border-gray-300 rounded px-3 py-2", min: 0 %>
+    </div>
+  </div>
+
+  <div class="grid grid-cols-2 gap-4">
+    <div>
+      <%= f.label :contacted_at, "初回接触日", class: "block text-sm font-medium text-gray-700 mb-1" %>
+      <%= f.date_field :contacted_at, class: "w-full border border-gray-300 rounded px-3 py-2" %>
+    </div>
+    <div>
+      <%= f.label :appointment_date, "アポ日", class: "block text-sm font-medium text-gray-700 mb-1" %>
+      <%= f.date_field :appointment_date, class: "w-full border border-gray-300 rounded px-3 py-2" %>
+    </div>
+  </div>
+
+  <div class="grid grid-cols-2 gap-4">
+    <div>
+      <%= f.label :visited_at, "訪問日", class: "block text-sm font-medium text-gray-700 mb-1" %>
+      <%= f.date_field :visited_at, class: "w-full border border-gray-300 rounded px-3 py-2" %>
+    </div>
+    <div>
+      <%= f.label :subsidy_status, "補助金申請状況", class: "block text-sm font-medium text-gray-700 mb-1" %>
+      <%= f.select :subsidy_status,
+            options_for_select(SalesLead::SUBSIDY_STATUSES, sales_lead.subsidy_status),
+            { include_blank: "選択してください" },
+            class: "w-full border border-gray-300 rounded px-3 py-2" %>
+    </div>
+  </div>
+
+  <div class="grid grid-cols-2 gap-4">
+    <div>
+      <%= f.label :closed_at, "成約日", class: "block text-sm font-medium text-gray-700 mb-1" %>
+      <%= f.date_field :closed_at, class: "w-full border border-gray-300 rounded px-3 py-2" %>
+    </div>
+    <div>
+      <%= f.label :monthly_start_date, "月額開始日", class: "block text-sm font-medium text-gray-700 mb-1" %>
+      <%= f.date_field :monthly_start_date, class: "w-full border border-gray-300 rounded px-3 py-2" %>
+    </div>
+  </div>
+
+  <h2 class="text-lg font-semibold border-b border-gray-300 pb-2 mt-6">データソース</h2>
+
+  <div class="grid grid-cols-2 gap-4">
+    <div>
+      <%= f.label :source, "ソース", class: "block text-sm font-medium text-gray-700 mb-1" %>
+      <%= f.text_field :source, class: "w-full border border-gray-300 rounded px-3 py-2" %>
+    </div>
+    <div>
+      <%= f.label :source_url, "ソースURL", class: "block text-sm font-medium text-gray-700 mb-1" %>
+      <%= f.url_field :source_url, class: "w-full border border-gray-300 rounded px-3 py-2" %>
+    </div>
+  </div>
+
+  <div>
+    <%= f.label :memo, "メモ", class: "block text-sm font-medium text-gray-700 mb-1" %>
+    <%= f.text_area :memo, rows: 3, class: "w-full border border-gray-300 rounded px-3 py-2" %>
+  </div>
+
+  <div class="flex items-center gap-4">
+    <%= f.submit sales_lead.new_record? ? "登録" : "更新", class: "bg-blue-600 text-white px-6 py-2 rounded hover:bg-blue-700 cursor-pointer" %>
+    <%= link_to "キャンセル", sales_leads_path, class: "text-gray-600 hover:underline" %>
+  </div>
+<% end %>

--- a/app/views/sales_leads/edit.html.erb
+++ b/app/views/sales_leads/edit.html.erb
@@ -1,0 +1,4 @@
+<div class="w-full">
+  <h1 class="text-2xl font-bold mb-6">営業先編集</h1>
+  <%= render "form", sales_lead: @sales_lead %>
+</div>

--- a/app/views/sales_leads/index.html.erb
+++ b/app/views/sales_leads/index.html.erb
@@ -1,0 +1,88 @@
+<div class="w-full">
+  <div class="flex justify-between items-center mb-6">
+    <h1 class="text-2xl font-bold">営業リスト</h1>
+    <%= link_to "新規登録", new_sales_lead_path, class: "bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700" %>
+  </div>
+
+  <%# フィルタ %>
+  <%= form_with url: sales_leads_path, method: :get, class: "flex flex-wrap gap-3 mb-6 items-end", data: { turbo_frame: "_top" } do |f| %>
+    <div>
+      <%= f.label :region, "地域", class: "block text-sm font-medium text-gray-700 mb-1" %>
+      <%= f.select :region,
+            options_for_select(SalesLead::REGIONS, params[:region]),
+            { include_blank: "すべて" },
+            class: "border border-gray-300 rounded px-3 py-2" %>
+    </div>
+    <div>
+      <%= f.label :segment, "セグメント", class: "block text-sm font-medium text-gray-700 mb-1" %>
+      <%= f.select :segment,
+            options_for_select(SalesLead::SEGMENTS, params[:segment]),
+            { include_blank: "すべて" },
+            class: "border border-gray-300 rounded px-3 py-2" %>
+    </div>
+    <div>
+      <%= f.label :priority, "優先度", class: "block text-sm font-medium text-gray-700 mb-1" %>
+      <%= f.select :priority,
+            options_for_select(SalesLead::PRIORITIES, params[:priority]),
+            { include_blank: "すべて" },
+            class: "border border-gray-300 rounded px-3 py-2" %>
+    </div>
+    <div>
+      <%= f.label :sales_status, "ステータス", class: "block text-sm font-medium text-gray-700 mb-1" %>
+      <%= f.select :sales_status,
+            options_for_select(SalesLead::SALES_STATUSES, params[:sales_status]),
+            { include_blank: "すべて" },
+            class: "border border-gray-300 rounded px-3 py-2" %>
+    </div>
+    <div>
+      <%= f.submit "絞り込み", class: "bg-gray-600 text-white px-4 py-2 rounded hover:bg-gray-700 cursor-pointer" %>
+      <%= link_to "クリア", sales_leads_path, class: "ml-2 text-gray-600 hover:underline" %>
+    </div>
+  <% end %>
+
+  <p class="text-sm text-gray-500 mb-4"><%= @sales_leads.size %>件</p>
+
+  <% if @sales_leads.any? %>
+    <div class="overflow-x-auto">
+      <table class="w-full border-collapse text-sm">
+        <thead>
+          <tr class="border-b-2 border-gray-300">
+            <th class="text-left py-3 px-2">施設名</th>
+            <th class="text-left py-3 px-2">地域</th>
+            <th class="text-left py-3 px-2">セグメント</th>
+            <th class="text-left py-3 px-2">電話番号</th>
+            <th class="text-left py-3 px-2">優先度</th>
+            <th class="text-left py-3 px-2">ステータス</th>
+            <th class="text-left py-3 px-2">担当者</th>
+            <th class="text-left py-3 px-2">操作</th>
+          </tr>
+        </thead>
+        <tbody>
+          <% @sales_leads.each do |lead| %>
+            <tr class="border-b border-gray-200 hover:bg-gray-50">
+              <td class="py-3 px-2 font-medium"><%= lead.facility_name %></td>
+              <td class="py-3 px-2"><%= lead.region %></td>
+              <td class="py-3 px-2"><%= lead.segment %></td>
+              <td class="py-3 px-2"><%= lead.phone %></td>
+              <td class="py-3 px-2">
+                <% if lead.priority.present? %>
+                  <span class="<%= priority_badge_class(lead.priority) %>"><%= lead.priority %></span>
+                <% end %>
+              </td>
+              <td class="py-3 px-2">
+                <span class="<%= sales_status_badge_class(lead.sales_status) %>"><%= lead.sales_status %></span>
+              </td>
+              <td class="py-3 px-2"><%= lead.person_in_charge %></td>
+              <td class="py-3 px-2 space-x-2">
+                <%= link_to "詳細", sales_lead_path(lead), class: "text-blue-600 hover:underline" %>
+                <%= link_to "編集", edit_sales_lead_path(lead), class: "text-blue-600 hover:underline" %>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+  <% else %>
+    <p class="text-gray-500">該当する営業先はありません。</p>
+  <% end %>
+</div>

--- a/app/views/sales_leads/new.html.erb
+++ b/app/views/sales_leads/new.html.erb
@@ -1,0 +1,4 @@
+<div class="w-full">
+  <h1 class="text-2xl font-bold mb-6">営業先登録</h1>
+  <%= render "form", sales_lead: @sales_lead %>
+</div>

--- a/app/views/sales_leads/show.html.erb
+++ b/app/views/sales_leads/show.html.erb
@@ -103,7 +103,7 @@
         <div>
           <dt class="text-gray-500">ソースURL</dt>
           <dd class="font-medium">
-            <% if @sales_lead.source_url.present? %>
+            <% if @sales_lead.source_url.present? && @sales_lead.source_url.match?(%r{\Ahttps?://}) %>
               <%= link_to truncate(@sales_lead.source_url, length: 40), @sales_lead.source_url, target: "_blank", rel: "noopener", class: "text-blue-600 hover:underline" %>
             <% else %>
               —

--- a/app/views/sales_leads/show.html.erb
+++ b/app/views/sales_leads/show.html.erb
@@ -1,0 +1,124 @@
+<div class="w-full max-w-3xl">
+  <div class="flex justify-between items-center mb-6">
+    <h1 class="text-2xl font-bold"><%= @sales_lead.facility_name %></h1>
+    <div class="space-x-2">
+      <%= link_to "編集", edit_sales_lead_path(@sales_lead), class: "bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700" %>
+      <%= link_to "一覧に戻る", sales_leads_path, class: "text-gray-600 hover:underline" %>
+    </div>
+  </div>
+
+  <% if @sales_lead.duplicate_flag? %>
+    <p class="mb-4 p-3 bg-yellow-50 border border-yellow-300 text-yellow-800 rounded text-sm">重複候補としてフラグされています</p>
+  <% end %>
+
+  <div class="space-y-6">
+    <%# 基本情報 %>
+    <section>
+      <h2 class="text-lg font-semibold border-b border-gray-300 pb-2 mb-3">基本情報</h2>
+      <dl class="grid grid-cols-2 gap-x-6 gap-y-3 text-sm">
+        <div>
+          <dt class="text-gray-500">地域</dt>
+          <dd class="font-medium"><%= @sales_lead.region %></dd>
+        </div>
+        <div>
+          <dt class="text-gray-500">市町村</dt>
+          <dd class="font-medium"><%= @sales_lead.area.presence || "—" %></dd>
+        </div>
+        <div>
+          <dt class="text-gray-500">セグメント</dt>
+          <dd class="font-medium"><%= @sales_lead.segment.presence || "—" %></dd>
+        </div>
+        <div>
+          <dt class="text-gray-500">電話番号</dt>
+          <dd class="font-medium"><%= @sales_lead.phone.presence || "—" %></dd>
+        </div>
+      </dl>
+    </section>
+
+    <%# 営業管理 %>
+    <section>
+      <h2 class="text-lg font-semibold border-b border-gray-300 pb-2 mb-3">営業管理</h2>
+      <dl class="grid grid-cols-2 gap-x-6 gap-y-3 text-sm">
+        <div>
+          <dt class="text-gray-500">優先度</dt>
+          <dd>
+            <% if @sales_lead.priority.present? %>
+              <span class="<%= priority_badge_class(@sales_lead.priority) %>"><%= @sales_lead.priority %></span>
+            <% else %>
+              —
+            <% end %>
+          </dd>
+        </div>
+        <div>
+          <dt class="text-gray-500">IT化度</dt>
+          <dd class="font-medium"><%= @sales_lead.it_literacy.presence || "—" %></dd>
+        </div>
+        <div>
+          <dt class="text-gray-500">ステータス</dt>
+          <dd><span class="<%= sales_status_badge_class(@sales_lead.sales_status) %>"><%= @sales_lead.sales_status %></span></dd>
+        </div>
+        <div>
+          <dt class="text-gray-500">担当者</dt>
+          <dd class="font-medium"><%= @sales_lead.person_in_charge.presence || "—" %></dd>
+        </div>
+        <div>
+          <dt class="text-gray-500">初回接触日</dt>
+          <dd class="font-medium"><%= @sales_lead.contacted_at&.strftime("%Y-%m-%d") || "—" %></dd>
+        </div>
+        <div>
+          <dt class="text-gray-500">アポ日</dt>
+          <dd class="font-medium"><%= @sales_lead.appointment_date&.strftime("%Y-%m-%d") || "—" %></dd>
+        </div>
+        <div>
+          <dt class="text-gray-500">訪問日</dt>
+          <dd class="font-medium"><%= @sales_lead.visited_at&.strftime("%Y-%m-%d") || "—" %></dd>
+        </div>
+        <div>
+          <dt class="text-gray-500">提案金額</dt>
+          <dd class="font-medium"><%= @sales_lead.proposal_amount ? "#{number_with_delimiter(@sales_lead.proposal_amount)}円" : "—" %></dd>
+        </div>
+        <div>
+          <dt class="text-gray-500">補助金申請状況</dt>
+          <dd class="font-medium"><%= @sales_lead.subsidy_status.presence || "—" %></dd>
+        </div>
+        <div>
+          <dt class="text-gray-500">成約日</dt>
+          <dd class="font-medium"><%= @sales_lead.closed_at&.strftime("%Y-%m-%d") || "—" %></dd>
+        </div>
+        <div>
+          <dt class="text-gray-500">月額開始日</dt>
+          <dd class="font-medium"><%= @sales_lead.monthly_start_date&.strftime("%Y-%m-%d") || "—" %></dd>
+        </div>
+      </dl>
+    </section>
+
+    <%# データソース %>
+    <section>
+      <h2 class="text-lg font-semibold border-b border-gray-300 pb-2 mb-3">データソース</h2>
+      <dl class="grid grid-cols-2 gap-x-6 gap-y-3 text-sm">
+        <div>
+          <dt class="text-gray-500">ソース</dt>
+          <dd class="font-medium"><%= @sales_lead.source.presence || "—" %></dd>
+        </div>
+        <div>
+          <dt class="text-gray-500">ソースURL</dt>
+          <dd class="font-medium">
+            <% if @sales_lead.source_url.present? %>
+              <%= link_to truncate(@sales_lead.source_url, length: 40), @sales_lead.source_url, target: "_blank", rel: "noopener", class: "text-blue-600 hover:underline" %>
+            <% else %>
+              —
+            <% end %>
+          </dd>
+        </div>
+      </dl>
+    </section>
+
+    <%# メモ %>
+    <% if @sales_lead.memo.present? %>
+      <section>
+        <h2 class="text-lg font-semibold border-b border-gray-300 pb-2 mb-3">メモ</h2>
+        <p class="text-sm whitespace-pre-wrap"><%= @sales_lead.memo %></p>
+      </section>
+    <% end %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,8 @@ Rails.application.routes.draw do
     end
   end
 
+  resources :sales_leads, only: %i[index show new create edit update]
+
   resources :users, only: %i[index new create edit update] do
     member do
       patch :toggle_active

--- a/db/migrate/20260424020554_create_sales_leads.rb
+++ b/db/migrate/20260424020554_create_sales_leads.rb
@@ -1,0 +1,37 @@
+class CreateSalesLeads < ActiveRecord::Migration[8.1]
+  def change
+    create_table :sales_leads do |t|
+      # 基本情報
+      t.string :facility_name, null: false, comment: "施設名"
+      t.string :segment, comment: "セグメント（大型ホテル・リゾート等）"
+      t.string :area, comment: "市町村"
+      t.string :phone, comment: "電話番号"
+      t.string :region, null: false, comment: "地域区分（北部 / 中部 / 南部）"
+
+      # 営業管理
+      t.string :priority, comment: "優先度"
+      t.string :it_literacy, comment: "IT化度推定"
+      t.string :sales_status, null: false, default: "未着手", comment: "営業ステータス"
+      t.string :person_in_charge, comment: "担当者"
+      t.date :contacted_at, comment: "初回接触日"
+      t.date :appointment_date, comment: "アポ日"
+      t.date :visited_at, comment: "訪問日"
+      t.integer :proposal_amount, comment: "提案金額（円・税抜）"
+      t.string :subsidy_status, comment: "補助金申請状況"
+      t.date :closed_at, comment: "成約日"
+      t.date :monthly_start_date, comment: "月額開始日"
+      t.text :memo, comment: "メモ"
+
+      # データソース情報
+      t.string :source, comment: "ソース分類"
+      t.string :source_url, comment: "ソースURL"
+      t.boolean :duplicate_flag, default: false, null: false, comment: "重複候補フラグ"
+
+      t.timestamps
+    end
+
+    add_index :sales_leads, :region
+    add_index :sales_leads, :sales_status
+    add_index :sales_leads, %i[facility_name phone region], unique: true, name: "index_sales_leads_on_unique_key"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,49 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_10_010000) do
+ActiveRecord::Schema[8.1].define(version: 2026_04_24_020554) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
+
+  create_table "inquiries", force: :cascade do |t|
+    t.string "contact_name", null: false, comment: "担当者名"
+    t.datetime "created_at", null: false
+    t.string "email", null: false, comment: "メールアドレス"
+    t.string "facility_name", null: false, comment: "施設名"
+    t.string "facility_type", comment: "施設の種類（minpaku / simple_lodging / ryokan / hotel / other）"
+    t.string "has_pc", comment: "PC保有状況（mac / windows / other_pc / no）"
+    t.text "message", comment: "ご相談内容"
+    t.string "phone", comment: "電話番号"
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "sales_leads", force: :cascade do |t|
+    t.date "appointment_date", comment: "アポ日"
+    t.string "area", comment: "市町村"
+    t.date "closed_at", comment: "成約日"
+    t.date "contacted_at", comment: "初回接触日"
+    t.datetime "created_at", null: false
+    t.boolean "duplicate_flag", default: false, null: false, comment: "重複候補フラグ"
+    t.string "facility_name", null: false, comment: "施設名"
+    t.string "it_literacy", comment: "IT化度推定"
+    t.text "memo", comment: "メモ"
+    t.date "monthly_start_date", comment: "月額開始日"
+    t.string "person_in_charge", comment: "担当者"
+    t.string "phone", comment: "電話番号"
+    t.string "priority", comment: "優先度"
+    t.integer "proposal_amount", comment: "提案金額（円・税抜）"
+    t.string "region", null: false, comment: "地域区分（北部 / 中部 / 南部）"
+    t.string "sales_status", default: "未着手", null: false, comment: "営業ステータス"
+    t.string "segment", comment: "セグメント（大型ホテル・リゾート等）"
+    t.string "source", comment: "ソース分類"
+    t.string "source_url", comment: "ソースURL"
+    t.string "subsidy_status", comment: "補助金申請状況"
+    t.datetime "updated_at", null: false
+    t.date "visited_at", comment: "訪問日"
+    t.index ["facility_name", "phone", "region"], name: "index_sales_leads_on_unique_key", unique: true
+    t.index ["region"], name: "index_sales_leads_on_region"
+    t.index ["sales_status"], name: "index_sales_leads_on_sales_status"
+  end
 
   create_table "stays", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "channel", comment: "予約チャネル名（Airbnb / Booking 等）"

--- a/lib/tasks/sales_leads.rake
+++ b/lib/tasks/sales_leads.rake
@@ -1,0 +1,29 @@
+namespace :sales_leads do
+  desc "Excel ファイルから営業先リストをインポート（冪等）"
+  task :import, [ :directory ] => :environment do |_t, args|
+    directory = args[:directory] || "tmp/import"
+
+    file_map = {
+      "north" => Dir.glob(File.join(directory, "*north*")).first,
+      "chubu" => Dir.glob(File.join(directory, "*chubu*")).first,
+      "south" => Dir.glob(File.join(directory, "*south*")).first
+    }
+
+    file_map.each do |region_key, file_path|
+      if file_path.nil?
+        puts "[SKIP] #{region_key}: ファイルが見つかりません (#{directory})"
+        next
+      end
+
+      puts "[START] #{region_key}: #{File.basename(file_path)}"
+      result = SalesLeadImporter.new(file_path, region_key: region_key).import
+      puts "  作成: #{result.created}, 更新: #{result.updated}, スキップ: #{result.skipped}"
+      if result.errors.any?
+        puts "  エラー (#{result.errors.size}件):"
+        result.errors.each { |e| puts "    #{e}" }
+      end
+      puts "[DONE] #{region_key}"
+      puts
+    end
+  end
+end

--- a/spec/factories/sales_leads.rb
+++ b/spec/factories/sales_leads.rb
@@ -1,0 +1,9 @@
+FactoryBot.define do
+  factory :sales_lead do
+    facility_name { Faker::Company.name }
+    region { SalesLead::REGIONS.sample }
+    area { "那覇市" }
+    phone { "098-#{rand(100..999)}-#{rand(1000..9999)}" }
+    sales_status { "未着手" }
+  end
+end

--- a/spec/models/sales_lead_spec.rb
+++ b/spec/models/sales_lead_spec.rb
@@ -1,0 +1,82 @@
+require "rails_helper"
+
+RSpec.describe SalesLead, type: :model do
+  describe "バリデーション" do
+    it "必須カラムが揃っていれば有効" do
+      lead = build(:sales_lead)
+      expect(lead).to be_valid
+    end
+
+    it "facility_name がなければ無効" do
+      lead = build(:sales_lead, facility_name: "")
+      expect(lead).not_to be_valid
+    end
+
+    it "region がなければ無効" do
+      lead = build(:sales_lead, region: "")
+      expect(lead).not_to be_valid
+    end
+
+    it "region が定義外の値なら無効" do
+      lead = build(:sales_lead, region: "東部")
+      expect(lead).not_to be_valid
+    end
+
+    it "sales_status が定義外の値なら無効" do
+      lead = build(:sales_lead, sales_status: "不明")
+      expect(lead).not_to be_valid
+    end
+
+    it "segment が定義外の値なら無効" do
+      lead = build(:sales_lead, segment: "不明なセグメント")
+      expect(lead).not_to be_valid
+    end
+
+    it "segment が空なら有効" do
+      lead = build(:sales_lead, segment: nil)
+      expect(lead).to be_valid
+    end
+
+    it "proposal_amount が負数なら無効" do
+      lead = build(:sales_lead, proposal_amount: -1)
+      expect(lead).not_to be_valid
+    end
+
+    it "proposal_amount が nil なら有効" do
+      lead = build(:sales_lead, proposal_amount: nil)
+      expect(lead).to be_valid
+    end
+  end
+
+  describe "スコープ" do
+    let!(:north_lead) { create(:sales_lead, region: "北部") }
+    let!(:south_lead) { create(:sales_lead, region: "南部") }
+
+    it ".by_region で地域を絞り込める" do
+      expect(SalesLead.by_region("北部")).to include(north_lead)
+      expect(SalesLead.by_region("北部")).not_to include(south_lead)
+    end
+
+    it ".by_region が空なら全件返す" do
+      expect(SalesLead.by_region("")).to include(north_lead, south_lead)
+    end
+
+    it ".by_sales_status でステータスを絞り込める" do
+      lead = create(:sales_lead, sales_status: "成約")
+      expect(SalesLead.by_sales_status("成約")).to include(lead)
+      expect(SalesLead.by_sales_status("成約")).not_to include(north_lead)
+    end
+  end
+
+  describe "デフォルト値" do
+    it "sales_status のデフォルトは '未着手'" do
+      lead = SalesLead.new
+      expect(lead.sales_status).to eq("未着手")
+    end
+
+    it "duplicate_flag のデフォルトは false" do
+      lead = SalesLead.new
+      expect(lead.duplicate_flag).to be false
+    end
+  end
+end

--- a/spec/requests/sales_leads_spec.rb
+++ b/spec/requests/sales_leads_spec.rb
@@ -1,0 +1,88 @@
+require "rails_helper"
+
+RSpec.describe "SalesLeads", type: :request do
+  let(:user) { create(:user) }
+
+  before { sign_in user }
+
+  describe "GET /sales_leads" do
+    it "営業リスト一覧を表示する" do
+      get sales_leads_path
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "地域フィルタで絞り込める" do
+      create(:sales_lead, region: "北部")
+      create(:sales_lead, region: "南部")
+      get sales_leads_path(region: "北部")
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe "GET /sales_leads/:id" do
+    it "詳細を表示する" do
+      lead = create(:sales_lead)
+      get sales_lead_path(lead)
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe "GET /sales_leads/new" do
+    it "入力フォームを表示する" do
+      get new_sales_lead_path
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe "POST /sales_leads" do
+    let(:valid_params) do
+      {
+        sales_lead: {
+          facility_name: "テストホテル",
+          region: "北部",
+          area: "名護市",
+          phone: "0980-12-3456",
+          segment: "民宿・ゲストハウス",
+          sales_status: "未着手"
+        }
+      }
+    end
+
+    it "営業先を登録できる" do
+      expect { post sales_leads_path, params: valid_params }.to change(SalesLead, :count).by(1)
+    end
+
+    it "登録後に一覧にリダイレクトする" do
+      post sales_leads_path, params: valid_params
+      expect(response).to redirect_to(sales_leads_path)
+    end
+
+    it "バリデーションエラー時は再表示する" do
+      post sales_leads_path, params: { sales_lead: { facility_name: "" } }
+      expect(response).to have_http_status(:unprocessable_entity)
+    end
+  end
+
+  describe "PATCH /sales_leads/:id" do
+    let(:lead) { create(:sales_lead) }
+
+    it "営業先を更新できる" do
+      patch sales_lead_path(lead), params: { sales_lead: { sales_status: "成約" } }
+      expect(lead.reload.sales_status).to eq("成約")
+    end
+
+    it "更新後に詳細にリダイレクトする" do
+      patch sales_lead_path(lead), params: { sales_lead: { sales_status: "成約" } }
+      expect(response).to redirect_to(sales_lead_path(lead))
+    end
+  end
+
+  describe "未認証アクセス" do
+    before { sign_out user }
+
+    it "ログインページにリダイレクトされる" do
+      get sales_leads_path
+      expect(response).to redirect_to(new_user_session_path)
+    end
+  end
+end

--- a/spec/services/sales_lead_importer_spec.rb
+++ b/spec/services/sales_lead_importer_spec.rb
@@ -1,0 +1,133 @@
+require "rails_helper"
+require "csv"
+
+RSpec.describe SalesLeadImporter do
+  def create_csv(filename, headers:, rows:)
+    path = Rails.root.join("tmp", filename)
+    CSV.open(path, "w") do |csv|
+      csv << headers
+      rows.each { |row| csv << row }
+    end
+    path.to_s
+  end
+
+  after do
+    FileUtils.rm_f(Dir.glob(Rails.root.join("tmp", "test_import_*.csv")))
+  end
+
+  describe "#import（南部・北部ファイル）" do
+    let(:file_path) do
+      create_csv(
+        "test_import_south.csv",
+        headers: %w[施設名 電話番号 エリア グループ ソース URL 重複候補],
+        rows: [
+          [ "ホテルA", "098-123-4567", "那覇市", "大型ホテル・リゾート", "OAH_那覇", "https://example.com", "" ],
+          [ "ホテルB", "098-234-5678", "浦添市", "民宿・ゲストハウス", "Mapion", "https://example2.com", "重複" ]
+        ]
+      )
+    end
+
+    it "CSVからインポートできる" do
+      result = described_class.new(file_path, region_key: "south").import
+      expect(result.created).to eq(2)
+      expect(result.errors).to be_empty
+    end
+
+    it "施設情報が正しく保存される" do
+      described_class.new(file_path, region_key: "south").import
+      lead = SalesLead.find_by(facility_name: "ホテルA")
+      expect(lead.region).to eq("南部")
+      expect(lead.area).to eq("那覇市")
+      expect(lead.phone).to eq("098-123-4567")
+      expect(lead.source).to eq("OAH_那覇")
+    end
+
+    it "重複候補フラグが設定される" do
+      described_class.new(file_path, region_key: "south").import
+      lead_b = SalesLead.find_by(facility_name: "ホテルB")
+      expect(lead_b.duplicate_flag).to be true
+    end
+  end
+
+  describe "冪等性" do
+    let(:file_path) do
+      create_csv(
+        "test_import_idempotent.csv",
+        headers: %w[施設名 電話番号 エリア],
+        rows: [ [ "テストホテル", "098-111-2222", "名護市" ] ]
+      )
+    end
+
+    it "同じファイルを2回実行しても重複しない" do
+      described_class.new(file_path, region_key: "north").import
+      result = described_class.new(file_path, region_key: "north").import
+
+      expect(SalesLead.where(facility_name: "テストホテル").count).to eq(1)
+      expect(result.created).to eq(0)
+      expect(result.updated).to eq(1)
+    end
+  end
+
+  describe "中部ファイル（営業管理カラム付き）" do
+    let(:file_path) do
+      create_csv(
+        "test_import_chubu.csv",
+        headers: %w[施設名 電話番号 市町村 セグメント名 優先度 IT化度 営業ステータス 担当者 提案金額],
+        rows: [ [ "リゾートC", "098-333-4444", "読谷村", "大型ホテル・リゾート", "高", "中", "アポ取得", "田中", "190万円" ] ]
+      )
+    end
+
+    it "営業管理カラムがインポートされる" do
+      described_class.new(file_path, region_key: "chubu").import
+      lead = SalesLead.find_by(facility_name: "リゾートC")
+
+      expect(lead.region).to eq("中部")
+      expect(lead.priority).to eq("高")
+      expect(lead.it_literacy).to eq("中")
+      expect(lead.sales_status).to eq("アポ取得")
+      expect(lead.person_in_charge).to eq("田中")
+      expect(lead.proposal_amount).to eq(1_900_000)
+    end
+  end
+
+  describe "空行スキップ" do
+    let(:file_path) do
+      create_csv(
+        "test_import_empty.csv",
+        headers: %w[施設名 電話番号],
+        rows: [ [ "", "098-000-0000" ], [ "有効なホテル", "098-111-0000" ] ]
+      )
+    end
+
+    it "施設名が空の行はスキップされる" do
+      result = described_class.new(file_path, region_key: "north").import
+      expect(result.skipped).to eq(1)
+      expect(result.created).to eq(1)
+    end
+  end
+
+  describe "parse_amount" do
+    let(:file_path) do
+      create_csv(
+        "test_import_amount.csv",
+        headers: %w[施設名 電話番号 市町村 セグメント名 提案金額],
+        rows: [
+          [ "ホテルX", "098-001-0001", "那覇市", "その他", "200万円" ],
+          [ "ホテルY", "098-001-0002", "那覇市", "その他", "1500000" ]
+        ]
+      )
+    end
+
+    it "'万円' 表記を整数に変換する" do
+      described_class.new(file_path, region_key: "chubu").import
+      expect(SalesLead.find_by(facility_name: "ホテルX").proposal_amount).to eq(2_000_000)
+      expect(SalesLead.find_by(facility_name: "ホテルY").proposal_amount).to eq(1_500_000)
+    end
+  end
+
+  describe "不正な region_key" do
+    it "ArgumentError を発生させる" do
+      expect { described_class.new("dummy.csv", region_key: "east") }.to raise_error(ArgumentError)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- `SalesLead` モデル・マイグレーション（22カラム、ユニークインデックス付き）
- CRUD画面（一覧フィルタ付き / 新規作成 / 編集 / 詳細表示）
- Excelインポートサービス（`SalesLeadImporter`）+ `rake sales_leads:import` タスク（冪等、万円パース対応）
- ナビゲーションに「営業リスト」リンク追加
- `roo` / `csv` gem 追加

## Test plan

- [x] RSpec 81件全て合格（新規32件 + 既存49件）
- [x] RuboCop 違反なし
- [x] ブラウザで CRUD 一通り動作確認（Railsコンソールで CREATE/READ/UPDATE/フィルタ/バリデーション検証済み）
- [x] Excelファイル3点での `rake sales_leads:import` 実行確認（北部61件 / 中部160件 / 南部258件 = 計479件、冪等性確認済み）

Closes #54